### PR TITLE
fix/Use `request` instead of `urllib` for robots.txt fetching

### DIFF
--- a/web_crawler.py
+++ b/web_crawler.py
@@ -127,7 +127,7 @@ class Worker:
                 time.sleep(0.5)
 
             print("Requesting " + str(url))
-            # self.driver.feget(url)
+            self.driver.get(curl)
             # TODO check if page is similar to some other one with the hash crap
             self.parse_page_content()
 


### PR DESCRIPTION
Changed the code to use `request` because `urllib` throw 
```
<urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate in certificate chain (_ssl.c:1045)>
```